### PR TITLE
 Add CSV export for all recipe materials to CraftPage.cs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Here's the original https://github.com/fsobolev/BitPlanner
 
 I only made this fork to add a CSV export with all materials, and not just with the base materials.
 
-All that's needed is to edit slightly CraftPage.cs.
+All that's needed is to edit CraftPage.cs slightly.
 Add the code on line 67 and the code on line 136 to 189 in the CraftPage.cs.  
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # BitPlanner
 
+Here's the original https://github.com/fsobolev/BitPlanner
+
+I only made this fork to add a CSV export with all materials, and not just with the base materials.
+
+All that's needed is to edit slightly CraftPage.cs.
+Add the code on line 67 and the code on line 136 to 189 in the CraftPage.cs.  
+
+
+
+
+*********
 ![](BitPlanner/icon.png)
 
 **BitPlanner** is a helper application for [BitCraft Online](https://bitcraftonline.com/) players. It works fully offline, available for Windows, Linux, OSX and Android. Features:

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Here's the original https://github.com/fsobolev/BitPlanner
 
 I only made this fork to add a CSV export with all materials, and not just with the base materials.
 
-All that's needed is to edit CraftPage.cs slightly.
-Add the code on line 67 and the code on line 136 to 189 in the CraftPage.cs.  
+I edited CraftPage.cs slightly.
+I added the code on line 67 and the code on line 136 to 189 in the CraftPage.cs.  
 
 ### [Download](https://github.com/Darokebi/BitPlanner/releases/latest)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ I only made this fork to add a CSV export with all materials, and not just with 
 All that's needed is to edit CraftPage.cs slightly.
 Add the code on line 67 and the code on line 136 to 189 in the CraftPage.cs.  
 
-
+### [Download](https://github.com/Darokebi/BitPlanner/releases/latest)
 
 
 *********
@@ -23,7 +23,7 @@ Add the code on line 67 and the code on line 136 to 189 in the CraftPage.cs.
 
 Statistics calculator with gathering time and effort calculations and other tools are planned for the future.
 
-### [Download](https://github.com/Darokebi/BitPlanner/releases/latest)
+### [Download](https://github.com/fsobolev/BitPlanner/releases/latest)
 
 ![](Screenshots/main.png)
 ![](Screenshots/crafting.png)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add the code on line 67 and the code on line 136 to 189 in the CraftPage.cs.
 
 Statistics calculator with gathering time and effort calculations and other tools are planned for the future.
 
-### [Download](https://github.com/fsobolev/BitPlanner/releases/latest)
+### [Download](https://github.com/Darokebi/BitPlanner/releases/latest)
 
 ![](Screenshots/main.png)
 ![](Screenshots/crafting.png)


### PR DESCRIPTION
This pull request introduces a feature that allows users to export all materials used in the recipe trees as a CSV file.
The change was made directly in CraftPage.cs, specifically on line 67 and between lines 136 to 189.

The CSV includes the following columns:
Item Name, Generic Name, Profession/Skill, Quantity, In Stock

This is useful for users who want a full material breakdown across all recipes, not just base ingredients.

The data is copied to the clipboard using DisplayServer.ClipboardSet, just like in the existing base ingredient CSV export.

I'm submitting this because I personally found the feature very useful, and I thought it might be something you'd consider including in the main project, either directly or as inspiration for your own implementation.

Thanks in advance, and great work on the project!